### PR TITLE
Fix counter sizing and improve voice playback

### DIFF
--- a/style.css
+++ b/style.css
@@ -160,6 +160,11 @@ h1 {
   transition: border-color var(--transition), background var(--transition);
 }
 
+#counter.dropzone.has-items {
+  justify-content: flex-start;
+  align-items: flex-start;
+}
+
 #counter.dropzone:hover {
   border-color: rgba(107, 91, 255, 0.8);
   background: rgba(107, 91, 255, 0.12);
@@ -170,6 +175,10 @@ h1 {
   margin: 0;
   color: var(--muted);
   font-weight: 500;
+}
+
+.dropzone .item {
+  flex: 0 0 auto;
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- prevent counter items from stretching by mirroring the shelf sizing and updating layout styles
- synchronize dropped item dimensions when the shelf changes or the window resizes
- initialize a Japanese speech synthesis voice and replay the prompt when voice playback is enabled

## Testing
- Manual testing in browser

------
https://chatgpt.com/codex/tasks/task_e_68dd696eefd8832487ae2d64a5e0cbf4