### PR TITLE
Add click-to-add interaction for shelf items

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         <div class="panel">
           <h2 class="section-title">Counter</h2>
           <div id="counter" class="dropzone">
-            <span class="drop-hint">Drag items here</span>
+            <span class="drop-hint">Drag or click items to add</span>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- allow shelf items to be added to the counter via clicks in addition to drag-and-drop
- centralize counter item creation and update the hint text to reflect the new interaction

## Testing
- Manual UI verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dd6bd52ff083248bf058490546ddca