### PR TITLE
Add prompt replay, hints, and detailed feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@
     <main id="game" class="game-panel">
       <section class="customer-card">
         <div id="customer" class="speech-bubble">「---」</div>
+        <button id="replayVoiceBtn" class="ghost inline">🔁 Replay audio</button>
         <div id="maruReaction" class="reaction"></div>
+        <div id="feedback" class="feedback" aria-live="polite"></div>
+        <div id="counterHint" class="hint-window"></div>
       </section>
 
       <section class="play-area">

--- a/style.css
+++ b/style.css
@@ -67,6 +67,25 @@ h1 {
   gap: 16px;
 }
 
+.customer-card .inline {
+  background: transparent;
+  color: var(--accent);
+  box-shadow: none;
+  border: 1px solid rgba(107, 91, 255, 0.25);
+  padding: 10px 18px;
+  font-size: 0.95rem;
+}
+
+.customer-card .inline:hover,
+.customer-card .inline:focus-visible {
+  background: rgba(107, 91, 255, 0.12);
+}
+
+.customer-card .inline:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .speech-bubble {
   padding: 16px 24px;
   border-radius: 16px;
@@ -91,6 +110,28 @@ h1 {
 
 .reaction img {
   filter: drop-shadow(0 12px 16px rgba(37, 33, 74, 0.18));
+}
+
+.feedback {
+  min-height: 24px;
+  font-weight: 500;
+  text-align: center;
+  color: var(--muted);
+}
+
+.feedback strong {
+  color: var(--accent-dark);
+}
+
+.hint-window {
+  padding: 16px 20px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(107, 91, 255, 0.12), rgba(255, 111, 145, 0.08));
+  color: var(--neutral);
+  font-size: 0.95rem;
+  text-align: center;
+  max-width: 420px;
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.18);
 }
 
 .play-area {


### PR DESCRIPTION
## Summary
- add a replay audio control for the current prompt and keep it in sync with voice settings
- display a contextual hint panel describing each counter and show text feedback for Maru's reactions
- clarify whether mistakes came from the item type or the quantity while keeping the reaction art visible longer

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd6e8440a88324b0d4951bf0ce82d6