### PR TITLE
Auto-start practice mode and stack counter items

### DIFF
--- a/style.css
+++ b/style.css
@@ -220,6 +220,22 @@ h1 {
 
 .dropzone .item {
   flex: 0 0 auto;
+  position: relative;
+  cursor: pointer;
+}
+
+.dropzone .item .item-count {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  background: rgba(31, 31, 43, 0.85);
+  color: white;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  box-shadow: 0 8px 16px -10px rgba(19, 17, 37, 0.55);
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- start practice mode automatically once the counter data finishes loading
- collapse duplicate counter items into a single tile with an "xN" badge and adjust removal logic
- ensure the done check counts stacked quantities so scoring remains accurate

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dd742ef2b08324b483ec649d957eac