### PR TITLE
Add dynamic scaling to fit viewport

### DIFF
--- a/game.js
+++ b/game.js
@@ -25,11 +25,54 @@ const challengeRoundSpan = document.getElementById("challengeRound");
 const challengeScoreSpan = document.getElementById("challengeScore");
 const streakCountSpan = document.getElementById("streakCount");
 const COUNTER_HINT_HTML = '<span class="drop-hint">Drag or click items to add</span>';
+const SCALE_EPSILON = 0.005;
 
 let hintVisible = false;
 
 const HINT_SHOW_LABEL = "💡 Show hint";
 const HINT_HIDE_LABEL = "🙈 Hide hint";
+
+function applyScaleToFit() {
+  const shell = document.querySelector(".app-shell");
+  const bodyEl = document.body;
+  if (!shell || !bodyEl) return;
+
+  shell.style.removeProperty("transform");
+  shell.style.removeProperty("transform-origin");
+  bodyEl.classList.remove("is-scaled");
+
+  const rect = shell.getBoundingClientRect();
+  if (!rect.width || !rect.height) return;
+
+  const bodyStyles = window.getComputedStyle(bodyEl);
+  const paddingX = parseFloat(bodyStyles.paddingLeft || "0") + parseFloat(bodyStyles.paddingRight || "0");
+  const paddingY = parseFloat(bodyStyles.paddingTop || "0") + parseFloat(bodyStyles.paddingBottom || "0");
+  const availableWidth = window.innerWidth - paddingX;
+  const availableHeight = window.innerHeight - paddingY;
+
+  if (availableWidth <= 0 || availableHeight <= 0) {
+    return;
+  }
+
+  const scale = Math.min(1, availableWidth / rect.width, availableHeight / rect.height);
+
+  if (scale < 1 - SCALE_EPSILON) {
+    shell.style.transform = `scale(${scale})`;
+    shell.style.transformOrigin = "top center";
+    bodyEl.classList.add("is-scaled");
+  }
+}
+
+const scheduleScaleToFit = () => window.requestAnimationFrame(applyScaleToFit);
+
+document.addEventListener("DOMContentLoaded", () => {
+  applyScaleToFit();
+  window.setTimeout(applyScaleToFit, 150);
+});
+
+window.addEventListener("load", applyScaleToFit);
+window.addEventListener("resize", scheduleScaleToFit);
+window.addEventListener("orientationchange", scheduleScaleToFit);
 
 function setHintVisibility(visible) {
   const canShow = counterHintDiv && counterHintDiv.innerHTML.trim().length > 0;

--- a/style.css
+++ b/style.css
@@ -26,6 +26,14 @@ body {
   padding: 40px 20px;
 }
 
+body.is-scaled {
+  align-items: flex-start;
+}
+
+body.is-scaled .app-shell {
+  margin-top: 16px;
+}
+
 h1 {
   margin: 0;
   font-size: clamp(2.2rem, 2.8vw, 3rem);


### PR DESCRIPTION
## Summary
- add a scale-to-fit helper that shrinks the app shell when the viewport is smaller than the layout
- adjust body styling to realign the scaled layout toward the top for better visibility on short screens

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68de39e5e6e08324959a295234744bd1