### PR TITLE
Add counter preferences page with stats tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,24 @@
         <input type="checkbox" id="voiceCheckbox"> Enable Voice
       </label>
       <br><br>
+      <button id="openCounterPage" class="ghost">Manage counters</button>
+      <br><br>
       <button id="closeSettings">Close</button>
+    </div>
+  </div>
+
+  <div id="counterPage" class="modal">
+    <div class="modal-content counter-modal" role="dialog" aria-modal="true" aria-labelledby="counterPageTitle">
+      <header class="counter-modal__header">
+        <h2 id="counterPageTitle">Counter preferences</h2>
+        <p>Select which counters appear in practice and review your accuracy.</p>
+      </header>
+      <div id="counterSummary" class="counter-summary"></div>
+      <div id="counterList" class="counter-list" role="list"></div>
+      <div class="counter-modal__actions">
+        <button id="selectAllCounters" class="ghost">Select all counters</button>
+        <button id="closeCounterPage">Done</button>
+      </div>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -401,6 +401,98 @@ button.primary:focus-visible {
   gap: 16px;
 }
 
+.counter-modal {
+  width: min(640px, 100%);
+  text-align: left;
+  gap: 20px;
+  max-height: 90vh;
+}
+
+.counter-modal__header p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.counter-summary {
+  font-weight: 600;
+  color: var(--accent-dark);
+  margin: -4px 0 4px;
+}
+
+.counter-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-right: 4px;
+  overflow-y: auto;
+  max-height: 50vh;
+}
+
+.counter-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(107, 91, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.16);
+}
+
+.counter-row__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.counter-row__header label {
+  flex: 1;
+  cursor: pointer;
+}
+
+.counter-row__header input[type="checkbox"] {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.counter-row__label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.counter-row__label strong {
+  font-size: 1.05rem;
+  color: var(--neutral);
+}
+
+.counter-row__label span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.counter-row__stats {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  color: var(--neutral);
+}
+
+.counter-row__stats span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.counter-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
 .modal-content h2 {
   margin: 0;
   font-size: 1.4rem;
@@ -445,5 +537,10 @@ input[type="checkbox"] {
 
   button {
     width: 100%;
+  }
+
+  .counter-modal__actions {
+    flex-direction: column;
+    align-items: stretch;
   }
 }


### PR DESCRIPTION
## Summary
- add a counter preferences modal reachable from the settings menu
- track per-counter practice statistics and respect the user’s selected counters during play
- style the new management view with responsive layouts for the list and action buttons

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e3739462a08324902538c10335103a