### PR TITLE
Add interactive clock and calendar drawers

### DIFF
--- a/data/counters.json
+++ b/data/counters.json
@@ -250,6 +250,120 @@
         { "id": "basketball",   "label_en": "basketball",   "label_ja": "バスケットボール", "image": "data/assets/items/basketball/basketball.png" },
         { "id": "tennis_ball",  "label_en": "tennis ball",  "label_ja": "テニスボール",    "image": "data/assets/items/tennis_ball/tennis_ball.png" }
       ]
+    },
+    {
+      "counter": "秒",
+      "reading": "びょう",
+      "irregular": { "default": "{n}びょう" },
+      "category": "time – seconds",
+      "practice": {
+        "type": "clock",
+        "hand": "seconds",
+        "min": 1,
+        "max": 59
+      },
+      "items": []
+    },
+    {
+      "counter": "分",
+      "reading": "ふん",
+      "irregular": {
+        "1": "いっぷん",
+        "3": "さんぷん",
+        "4": "よんぷん",
+        "6": "ろっぷん",
+        "8": "はっぷん",
+        "10": "じゅっぷん",
+        "default": "{n}ふん"
+      },
+      "category": "time – minutes",
+      "practice": {
+        "type": "clock",
+        "hand": "minutes",
+        "min": 1,
+        "max": 59
+      },
+      "items": []
+    },
+    {
+      "counter": "時間",
+      "reading": "じかん",
+      "irregular": {
+        "4": "よじかん",
+        "default": "{n}じかん"
+      },
+      "category": "time – hours",
+      "practice": {
+        "type": "clock",
+        "hand": "hours",
+        "min": 1,
+        "max": 12
+      },
+      "items": []
+    },
+    {
+      "counter": "日間",
+      "reading": "にちかん",
+      "irregular": {
+        "1": "いちにち",
+        "2": "ふつかかん",
+        "3": "みっかかん",
+        "4": "よっかかん",
+        "5": "いつかかん",
+        "6": "むいかかん",
+        "7": "なのかかん",
+        "8": "ようかかん",
+        "9": "ここのかかん",
+        "10": "とおかかん",
+        "default": "{n}にちかん"
+      },
+      "category": "time – days",
+      "practice": {
+        "type": "calendar",
+        "mode": "days",
+        "min": 1,
+        "max": 28
+      },
+      "items": []
+    },
+    {
+      "counter": "週間",
+      "reading": "しゅうかん",
+      "irregular": {
+        "1": "いっしゅうかん",
+        "6": "ろくしゅうかん",
+        "8": "はっしゅうかん",
+        "10": "じゅっしゅうかん",
+        "default": "{n}しゅうかん"
+      },
+      "category": "time – weeks",
+      "practice": {
+        "type": "calendar",
+        "mode": "weeks",
+        "min": 1,
+        "max": 4
+      },
+      "items": []
+    },
+    {
+      "counter": "ヶ月",
+      "reading": "かげつ",
+      "irregular": {
+        "1": "いっかげつ",
+        "3": "さんかげつ",
+        "6": "ろっかげつ",
+        "8": "はっかげつ",
+        "10": "じゅっかげつ",
+        "default": "{n}かげつ"
+      },
+      "category": "time – months",
+      "practice": {
+        "type": "calendar",
+        "mode": "months",
+        "min": 1,
+        "max": 12
+      },
+      "items": []
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -13,6 +13,24 @@
     </header>
 
     <main id="game" class="game-panel">
+      <div class="drawer-launchers" role="group" aria-label="Counter tools">
+        <button
+          type="button"
+          class="drawer-launcher"
+          data-drawer-toggle="clock"
+          aria-controls="clockDrawer"
+          aria-expanded="false"
+          title="Open clock counter"
+        >🕒</button>
+        <button
+          type="button"
+          class="drawer-launcher"
+          data-drawer-toggle="calendar"
+          aria-controls="calendarDrawer"
+          aria-expanded="false"
+          title="Open calendar counter"
+        >📅</button>
+      </div>
       <section class="customer-card">
         <div id="customer" class="speech-bubble">「---」</div>
         <button id="replayVoiceBtn" class="ghost inline">🔁 Replay audio</button>
@@ -102,6 +120,49 @@
       </div>
     </div>
   </div>
+
+  <div id="drawerOverlay" class="drawer-overlay" hidden></div>
+  <aside id="drawerContainer" class="drawer-container" aria-hidden="true">
+    <div id="clockDrawer" class="drawer-panel clock-drawer" data-drawer="clock" hidden>
+      <header class="drawer-header">
+        <h2 class="drawer-title">Clock counter</h2>
+        <p class="drawer-subtitle">Drag each hand to set the time requested.</p>
+      </header>
+      <div class="clock-face-wrapper">
+        <div class="clock-face" id="clockFace" role="presentation">
+          <div id="clockMarkers" class="clock-markers" aria-hidden="true"></div>
+          <div class="clock-hand hour-hand" data-hand="hours" aria-label="Hour hand" role="slider" aria-valuemin="0" aria-valuemax="11" aria-valuenow="0"></div>
+          <div class="clock-hand minute-hand" data-hand="minutes" aria-label="Minute hand" role="slider" aria-valuemin="0" aria-valuemax="59" aria-valuenow="0"></div>
+          <div class="clock-hand second-hand" data-hand="seconds" aria-label="Second hand" role="slider" aria-valuemin="0" aria-valuemax="59" aria-valuenow="0"></div>
+          <div class="clock-center" aria-hidden="true"></div>
+        </div>
+        <div id="clockValue" class="clock-value" aria-live="polite">00:00:00</div>
+      </div>
+      <div class="drawer-actions">
+        <button id="clockDoneBtn" type="button" class="primary">✅ Done</button>
+      </div>
+    </div>
+
+    <div id="calendarDrawer" class="drawer-panel calendar-drawer" data-drawer="calendar" hidden>
+      <header class="drawer-header">
+        <h2 class="drawer-title">Calendar counter</h2>
+      </header>
+      <div class="calendar-meta">
+        <div class="calendar-info">
+          <p id="calendarModeLabel" class="drawer-subtitle"></p>
+          <span id="calendarTarget" class="calendar-target"></span>
+        </div>
+        <div class="calendar-controls">
+          <button id="calendarTearBtn" type="button" class="ghost">🗓️ Tear off page</button>
+          <span id="calendarSelectionCount" class="calendar-count" aria-live="polite">Marked: 0</span>
+        </div>
+      </div>
+      <div id="calendarGrid" class="calendar-grid" aria-live="polite"></div>
+      <div class="drawer-actions">
+        <button id="calendarDoneBtn" type="button" class="primary">✅ Done</button>
+      </div>
+    </div>
+  </aside>
 
   <script src="game.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -136,7 +136,16 @@
           <div class="clock-hand second-hand" data-hand="seconds" aria-label="Second hand" role="slider" aria-valuemin="0" aria-valuemax="59" aria-valuenow="0"></div>
           <div class="clock-center" aria-hidden="true"></div>
         </div>
-        <div id="clockValue" class="clock-value" aria-live="polite">00:00:00</div>
+        <input
+          id="clockValue"
+          class="clock-value"
+          type="text"
+          aria-live="polite"
+          aria-label="Selected time"
+          autocomplete="off"
+          spellcheck="false"
+          value="00:00:00"
+        />
       </div>
       <div class="drawer-actions">
         <button id="clockDoneBtn" type="button" class="primary">✅ Done</button>

--- a/style.css
+++ b/style.css
@@ -594,7 +594,7 @@ input[type="checkbox"] {
   position: fixed;
   top: 0;
   right: 0;
-  width: min(360px, 85vw);
+  width: min(720px, 95vw);
   height: 100vh;
   padding: 32px 28px 36px;
   background: rgba(255, 255, 255, 0.92);
@@ -806,7 +806,7 @@ input[type="checkbox"] {
 
 .calendar-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 16px;
   transition: opacity var(--transition), transform var(--transition);
 }
@@ -892,7 +892,7 @@ input[type="checkbox"] {
 
 @media (max-width: 680px) {
   .calendar-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(180px, 1fr));
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -66,6 +66,7 @@ h1 {
   box-shadow: var(--shadow);
   padding: 32px clamp(24px, 5vw, 48px);
   backdrop-filter: blur(18px);
+  position: relative;
 }
 
 .customer-card {
@@ -514,6 +515,389 @@ input[type="checkbox"] {
 
 @media (max-width: 900px) {
   .play-area {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Drawer launchers */
+.drawer-launchers {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 5;
+}
+
+.drawer-launcher {
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(255, 111, 145, 0.8));
+  box-shadow: 0 18px 40px -20px rgba(81, 66, 208, 0.7);
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.drawer-launcher:hover,
+.drawer-launcher:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 48px -22px rgba(81, 66, 208, 0.85);
+}
+
+.drawer-launcher.is-active {
+  box-shadow: 0 20px 48px -18px rgba(81, 66, 208, 0.9);
+  background: linear-gradient(135deg, rgba(107, 91, 255, 1), rgba(255, 111, 145, 0.95));
+}
+
+@media (max-width: 840px) {
+  .drawer-launchers {
+    position: fixed;
+    top: auto;
+    bottom: 24px;
+    right: 24px;
+    flex-direction: row;
+    z-index: 60;
+  }
+}
+
+@media (max-width: 520px) {
+  .drawer-launcher {
+    width: 48px;
+    height: 48px;
+    font-size: 1.4rem;
+  }
+}
+
+/* Drawer shell */
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(31, 31, 43, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease;
+  z-index: 40;
+}
+
+.drawer-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.drawer-container {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(360px, 85vw);
+  height: 100vh;
+  padding: 32px 28px 36px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: -18px 0 42px -24px rgba(44, 35, 92, 0.45);
+  backdrop-filter: blur(22px);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  transform: translateX(100%);
+  transition: transform 260ms ease;
+  z-index: 50;
+  pointer-events: none;
+}
+
+.drawer-container.is-open {
+  pointer-events: auto;
+}
+
+.drawer-container.is-active {
+  transform: translateX(0);
+}
+
+.drawer-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.drawer-panel[hidden] {
+  display: none;
+}
+
+.drawer-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.drawer-title {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.drawer-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.drawer-actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Clock drawer */
+.clock-face-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.clock-face {
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.96), rgba(233, 228, 255, 0.9));
+  border: 6px solid rgba(107, 91, 255, 0.15);
+  box-shadow: inset 0 0 0 2px rgba(107, 91, 255, 0.12), 0 24px 40px -28px rgba(44, 35, 92, 0.4);
+  position: relative;
+}
+
+.clock-markers {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.clock-marker {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: rotate(var(--marker-rotation)) translateY(-92px) rotate(calc(-1 * var(--marker-rotation)));
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+.clock-hand {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform-origin: center calc(100%);
+  transform: translate(-50%, -100%) rotate(var(--rotation, 0deg));
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 12px 28px -20px rgba(81, 66, 208, 0.75);
+  cursor: grab;
+  touch-action: none;
+  transition: transform 80ms ease;
+}
+
+.clock-hand::after {
+  content: "";
+  position: absolute;
+  bottom: -12px;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: inherit;
+  transform: translate(-50%, 0);
+  opacity: 0.6;
+}
+
+.clock-hand.hour-hand {
+  width: 12px;
+  height: 70px;
+  z-index: 2;
+}
+
+.clock-hand.minute-hand {
+  width: 8px;
+  height: 90px;
+  background: linear-gradient(180deg, rgba(107, 91, 255, 1), rgba(255, 111, 145, 0.9));
+  z-index: 3;
+}
+
+.clock-hand.second-hand {
+  width: 4px;
+  height: 104px;
+  background: linear-gradient(180deg, rgba(255, 111, 145, 1), rgba(255, 151, 112, 1));
+  box-shadow: 0 10px 22px -18px rgba(255, 111, 145, 0.8);
+  z-index: 4;
+}
+
+.clock-hand.is-active {
+  cursor: grabbing;
+}
+
+.clock-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #ff9770, #ff6f91);
+  box-shadow: 0 10px 20px -16px rgba(255, 111, 145, 0.85);
+  transform: translate(-50%, -50%);
+}
+
+.clock-value {
+  font-family: 'Poppins', 'Noto Sans JP', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  color: var(--accent-dark);
+  background: rgba(107, 91, 255, 0.08);
+  border-radius: 999px;
+  padding: 8px 18px;
+}
+
+/* Calendar drawer */
+.calendar-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.calendar-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.calendar-target {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--accent-dark);
+}
+
+.calendar-controls {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+#calendarTearBtn {
+  display: none;
+  white-space: nowrap;
+}
+
+.calendar-drawer--mode-years #calendarTearBtn {
+  display: inline-flex;
+}
+
+.calendar-count {
+  font-weight: 600;
+  color: var(--accent-dark);
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  transition: opacity var(--transition), transform var(--transition);
+}
+
+.calendar-grid.is-torn {
+  opacity: 0;
+  transform: translateY(16px);
+  pointer-events: none;
+}
+
+.calendar-month {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 18px;
+  padding: 16px 14px 18px;
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: transform var(--transition), box-shadow var(--transition);
+  cursor: pointer;
+}
+
+.calendar-month__name {
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.calendar-month.is-selected {
+  transform: translateY(-3px);
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.3), 0 20px 36px -26px rgba(44, 35, 92, 0.45);
+}
+
+.calendar-week {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+  padding: 6px 4px;
+  border-radius: 12px;
+  transition: background var(--transition), box-shadow var(--transition);
+  touch-action: none;
+}
+
+.calendar-week.is-selected {
+  background: rgba(107, 91, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.18);
+}
+
+.calendar-day {
+  aspect-ratio: 1;
+  border-radius: 8px;
+  background: rgba(107, 91, 255, 0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--muted);
+  transition: transform var(--transition), background var(--transition), color var(--transition);
+  user-select: none;
+  cursor: pointer;
+}
+
+.calendar-day:hover {
+  background: rgba(107, 91, 255, 0.16);
+}
+
+.calendar-day.is-selected {
+  background: rgba(107, 91, 255, 0.32);
+  color: var(--accent-dark);
+  transform: translateY(-2px);
+}
+
+.calendar-drawer--mode-months .calendar-month {
+  cursor: pointer;
+}
+
+.calendar-drawer--mode-weeks .calendar-day,
+.calendar-drawer--mode-months .calendar-day,
+.calendar-drawer--mode-years .calendar-day {
+  cursor: default;
+}
+
+@media (max-width: 680px) {
+  .calendar-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .calendar-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/style.css
+++ b/style.css
@@ -759,6 +759,20 @@ input[type="checkbox"] {
   background: rgba(107, 91, 255, 0.08);
   border-radius: 999px;
   padding: 8px 18px;
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  text-align: center;
+  min-width: 140px;
+  cursor: text;
+  outline: none;
+}
+
+.clock-value:focus {
+  border-color: rgba(107, 91, 255, 0.35);
+  box-shadow: 0 0 0 3px rgba(107, 91, 255, 0.12);
 }
 
 /* Calendar drawer */


### PR DESCRIPTION
## Summary
- add clock and calendar drawer launchers and panels to the main game layout
- implement analog clock dragging, calendar selection modes, and callbacks in game logic
- style the new drawer interface to match the existing aesthetic with transitions and responsive tweaks

## Testing
- Manual verification via Playwright screenshot of the clock drawer

------
https://chatgpt.com/codex/tasks/task_e_68e3b05a41208324908bbf9ab8456328