### PR TITLE
Increase calendar drawer width to prevent day overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -594,7 +594,7 @@ input[type="checkbox"] {
   position: fixed;
   top: 0;
   right: 0;
-  width: min(360px, 85vw);
+  width: min(720px, 95vw);
   height: 100vh;
   padding: 32px 28px 36px;
   background: rgba(255, 255, 255, 0.92);
@@ -806,7 +806,7 @@ input[type="checkbox"] {
 
 .calendar-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 16px;
   transition: opacity var(--transition), transform var(--transition);
 }
@@ -892,7 +892,7 @@ input[type="checkbox"] {
 
 @media (max-width: 680px) {
   .calendar-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(180px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- expand the drawer width so the calendar can slide out further
- widen the calendar grid columns to give each month more space for its days

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3b988195c832496bc141205737075