### PR TITLE
Add house practice drawer with interactive floor plan

### DIFF
--- a/data/counters.json
+++ b/data/counters.json
@@ -59,6 +59,12 @@
       },
       "category": "long cylindrical objects",
       "icon": "data/assets/counters/hon.png",
+      "practice": {
+        "type": "house",
+        "target": "trees",
+        "min": 1,
+        "max": 3
+      },
       "items": [
         { "id": "carrot", "label_en": "carrot", "label_ja": "にんじん", "image": "data/assets/items/carrot/carrot.png" },
         { "id": "bottle", "label_en": "bottle", "label_ja": "ボトル",   "image": "data/assets/items/bottle/bottle.png" },
@@ -71,6 +77,12 @@
       "irregular": { "default": "{n}まい" },
       "category": "flat objects",
       "icon": "data/assets/counters/mai.png",
+      "practice": {
+        "type": "house",
+        "target": "windows",
+        "min": 1,
+        "max": 6
+      },
       "items": [
         { "id": "paper",       "label_en": "sheet of paper", "label_ja": "紙",         "image": "data/assets/items/paper/paper.png" },
         { "id": "cd",          "label_en": "CD",             "label_ja": "CD",         "image": "data/assets/items/cd/cd.png" },
@@ -83,11 +95,64 @@
       "irregular": { "default": "{n}だい" },
       "category": "machines/vehicles",
       "icon": "data/assets/counters/dai.png",
+      "practice": {
+        "type": "house",
+        "target": "cars",
+        "min": 1,
+        "max": 3
+      },
       "items": [
         { "id": "car",        "label_en": "car",        "label_ja": "車",       "image": "data/assets/items/car/car.png" },
         { "id": "computer",   "label_en": "computer",   "label_ja": "コンピューター","image": "data/assets/items/computer/computer.png" },
         { "id": "game_console","label_en": "game console","label_ja": "ゲーム機","image": "data/assets/items/game_console/game_console.png" }
       ]
+    },
+    {
+      "counter": "階",
+      "reading": "かい",
+      "irregular": {
+        "1": "いっかい",
+        "3": "さんがい",
+        "4": "よんかい",
+        "6": "ろっかい",
+        "8": "はっかい",
+        "10": "じゅっかい",
+        "default": "{n}かい"
+      },
+      "category": "building floors",
+      "practice": {
+        "type": "house",
+        "target": "floors",
+        "min": 1,
+        "max": 3
+      },
+      "items": []
+    },
+    {
+      "counter": "部屋",
+      "reading": "へや",
+      "irregular": { "default": "{n}へや" },
+      "category": "rooms in a building",
+      "practice": {
+        "type": "house",
+        "target": "rooms",
+        "min": 1,
+        "max": 6
+      },
+      "items": []
+    },
+    {
+      "counter": "畳",
+      "reading": "じょう",
+      "irregular": { "default": "{n}じょう" },
+      "category": "tatami mats",
+      "practice": {
+        "type": "house",
+        "target": "tatami",
+        "min": 1,
+        "max": 12
+      },
+      "items": []
     },
     {
       "counter": "個",

--- a/index.html
+++ b/index.html
@@ -188,8 +188,8 @@
       <div class="house-layout">
         <section id="houseFloorPlan" class="house-floor-plan" aria-label="Floor plan"></section>
         <section id="houseSideView" class="house-side-view" aria-label="Side view"></section>
+        <section id="houseOutdoor" class="house-outdoor" aria-label="Outside area"></section>
       </div>
-      <section id="houseOutdoor" class="house-outdoor" aria-label="Outside area"></section>
       <div id="houseSelectionSummary" class="house-selection-summary" aria-live="polite"></div>
       <div class="drawer-actions">
         <button id="houseDoneBtn" type="button" class="primary">✅ Done</button>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,14 @@
           aria-expanded="false"
           title="Open calendar counter"
         >📅</button>
+        <button
+          type="button"
+          class="drawer-launcher"
+          data-drawer-toggle="house"
+          aria-controls="houseDrawer"
+          aria-expanded="false"
+          title="Open house counter"
+        >🏠</button>
       </div>
       <section class="customer-card">
         <div id="customer" class="speech-bubble">「---」</div>
@@ -169,6 +177,22 @@
       <div id="calendarGrid" class="calendar-grid" aria-live="polite"></div>
       <div class="drawer-actions">
         <button id="calendarDoneBtn" type="button" class="primary">✅ Done</button>
+      </div>
+    </div>
+
+    <div id="houseDrawer" class="drawer-panel house-drawer" data-drawer="house" hidden>
+      <header class="drawer-header">
+        <h2 class="drawer-title">House counter</h2>
+        <p class="drawer-subtitle">Tap areas around the house to match Maru&rsquo;s request.</p>
+      </header>
+      <div class="house-layout">
+        <section id="houseFloorPlan" class="house-floor-plan" aria-label="Floor plan"></section>
+        <section id="houseSideView" class="house-side-view" aria-label="Side view"></section>
+      </div>
+      <section id="houseOutdoor" class="house-outdoor" aria-label="Outside area"></section>
+      <div id="houseSelectionSummary" class="house-selection-summary" aria-live="polite"></div>
+      <div class="drawer-actions">
+        <button id="houseDoneBtn" type="button" class="primary">✅ Done</button>
       </div>
     </div>
   </aside>

--- a/style.css
+++ b/style.css
@@ -652,6 +652,261 @@ input[type="checkbox"] {
   justify-content: flex-end;
 }
 
+/* House drawer */
+.house-drawer {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.house-layout {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.house-floor-plan,
+.house-side-view,
+.house-outdoor {
+  background: linear-gradient(160deg, rgba(107, 91, 255, 0.12), rgba(255, 111, 145, 0.08));
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.house-outdoor-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.house-floor-plan__level {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.house-floor-plan__label {
+  font-weight: 600;
+  color: var(--accent-dark);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.house-floor-plan__rooms {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.house-room {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 14px;
+  padding: 10px;
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.house-toggle {
+  border: none;
+  background: rgba(107, 91, 255, 0.12);
+  color: var(--muted);
+  font-weight: 600;
+  border-radius: 12px;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 40px;
+}
+
+.house-toggle:hover,
+.house-toggle:focus-visible {
+  background: rgba(107, 91, 255, 0.18);
+  box-shadow: 0 10px 24px -18px rgba(81, 66, 208, 0.7);
+}
+
+.house-toggle.is-selected {
+  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(255, 111, 145, 0.85));
+  color: white;
+  box-shadow: 0 18px 36px -20px rgba(81, 66, 208, 0.75);
+}
+
+.house-toggle.is-target:not(.is-selected) {
+  box-shadow: inset 0 0 0 2px rgba(107, 91, 255, 0.4);
+}
+
+.house-tatami-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.house-tatami {
+  aspect-ratio: 1 / 1;
+  border-radius: 10px;
+  border: none;
+  background: rgba(107, 91, 255, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.25);
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.house-tatami:hover,
+.house-tatami:focus-visible {
+  background: rgba(107, 91, 255, 0.18);
+}
+
+.house-tatami.is-selected {
+  background: linear-gradient(135deg, rgba(107, 91, 255, 0.88), rgba(255, 111, 145, 0.75));
+  box-shadow: 0 12px 28px -18px rgba(81, 66, 208, 0.7);
+}
+
+.house-tatami.is-target:not(.is-selected) {
+  box-shadow: inset 0 0 0 2px rgba(107, 91, 255, 0.4);
+}
+
+.house-side-levels {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.house-side-level {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.house-window-row {
+  display: none;
+  gap: 10px;
+}
+
+.house-window {
+  flex: 1;
+  border-radius: 12px;
+  border: none;
+  padding: 14px 0;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.2);
+  cursor: pointer;
+  transition: background var(--transition), box-shadow var(--transition);
+}
+
+.house-window:hover,
+.house-window:focus-visible {
+  background: rgba(107, 91, 255, 0.16);
+}
+
+.house-window.is-selected {
+  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(255, 111, 145, 0.85));
+  color: white;
+  box-shadow: 0 16px 32px -18px rgba(81, 66, 208, 0.75);
+}
+
+.house-window.is-target:not(.is-selected) {
+  box-shadow: inset 0 0 0 2px rgba(107, 91, 255, 0.45);
+}
+
+.house-drawer--windows .house-floor-toggle {
+  display: none;
+}
+
+.house-drawer--windows .house-window-row {
+  display: flex;
+}
+
+.house-outdoor-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.house-outdoor-label {
+  font-weight: 600;
+  color: var(--accent-dark);
+}
+
+.house-car,
+.house-tree {
+  border: none;
+  border-radius: 16px;
+  padding: 16px 0;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.2);
+  cursor: pointer;
+  font-size: 1.6rem;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.house-car:hover,
+.house-car:focus-visible,
+.house-tree:hover,
+.house-tree:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px -22px rgba(81, 66, 208, 0.8);
+}
+
+.house-car.is-selected,
+.house-tree.is-selected {
+  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(255, 111, 145, 0.85));
+  color: white;
+}
+
+.house-car.is-target:not(.is-selected),
+.house-tree.is-target:not(.is-selected) {
+  box-shadow: inset 0 0 0 2px rgba(107, 91, 255, 0.45);
+}
+
+.house-selection-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.16);
+}
+
+.house-summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.house-summary-item strong {
+  font-size: 1.2rem;
+  color: var(--accent-dark);
+}
+
+.house-summary-item.is-target {
+  background: linear-gradient(135deg, rgba(107, 91, 255, 0.12), rgba(255, 111, 145, 0.1));
+  border-radius: 12px;
+  padding: 10px;
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.2);
+}
+
+@media (max-width: 640px) {
+  .house-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .house-floor-plan__rooms {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 /* Clock drawer */
 .clock-face-wrapper {
   display: flex;

--- a/style.css
+++ b/style.css
@@ -657,85 +657,166 @@ input[type="checkbox"] {
   display: flex;
   flex-direction: column;
   gap: 24px;
+  align-items: stretch;
 }
 
 .house-layout {
   display: grid;
-  gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 28px;
+  grid-template-columns: minmax(320px, 1fr) minmax(220px, 0.75fr);
+  grid-template-areas:
+    "plan side"
+    "outdoor side";
+  justify-content: center;
+  align-items: start;
+  margin: 0 auto;
+  max-width: 760px;
+}
+
+.house-floor-plan {
+  grid-area: plan;
+}
+
+.house-side-view {
+  grid-area: side;
+  justify-content: space-between;
+}
+
+.house-outdoor {
+  grid-area: outdoor;
+  align-items: center;
+  text-align: center;
+}
+
+.house-outdoor::after {
+  content: "";
+  position: absolute;
+  left: 10%;
+  right: 10%;
+  bottom: 18px;
+  height: 4px;
+  background: linear-gradient(90deg, rgba(107, 134, 255, 0.45), rgba(108, 190, 255, 0.55));
+  border-radius: 999px;
+  pointer-events: none;
 }
 
 .house-floor-plan,
 .house-side-view,
 .house-outdoor {
-  background: linear-gradient(160deg, rgba(107, 91, 255, 0.12), rgba(255, 111, 145, 0.08));
-  border-radius: 18px;
-  padding: 18px;
-  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.16);
+  position: relative;
+  border-radius: 22px;
+  padding: 24px 24px 28px;
+  background: rgba(229, 239, 255, 0.9);
+  box-shadow: inset 0 0 0 1.5px rgba(97, 128, 228, 0.35), 0 18px 36px -26px rgba(65, 78, 146, 0.45);
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 20px;
+}
+
+.house-floor-plan::before,
+.house-side-view::before,
+.house-outdoor::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(90deg, rgba(126, 155, 255, 0.15) 1px, transparent 1px),
+    linear-gradient(rgba(126, 155, 255, 0.15) 1px, transparent 1px);
+  background-size: 28px 28px;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.house-floor-plan > *,
+.house-side-view > *,
+.house-outdoor > * {
+  position: relative;
+  z-index: 1;
 }
 
 .house-outdoor-section {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
+  align-items: center;
 }
 
 .house-floor-plan__level {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+  background: rgba(255, 255, 255, 0.68);
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1.5px rgba(126, 155, 255, 0.35);
+  transition: transform var(--transition);
+}
+
+.house-floor-plan__level:hover {
+  transform: translateY(-2px);
 }
 
 .house-floor-plan__label {
-  font-weight: 600;
+  font-weight: 700;
   color: var(--accent-dark);
   display: flex;
   justify-content: space-between;
   align-items: center;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+}
+
+.house-floor-plan__label span:first-child {
+  font-size: 1rem;
+  letter-spacing: 0.12em;
+}
+
+.house-floor-plan__label span:last-child {
+  font-size: 1.2rem;
 }
 
 .house-floor-plan__rooms {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
 }
 
 .house-room {
-  background: rgba(255, 255, 255, 0.75);
+  background: rgba(255, 255, 255, 0.74);
   border-radius: 14px;
-  padding: 10px;
-  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.12);
+  padding: 12px;
+  box-shadow: inset 0 0 0 1.5px rgba(126, 155, 255, 0.35);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
+  align-items: stretch;
 }
 
 .house-toggle {
   border: none;
-  background: rgba(107, 91, 255, 0.12);
+  background: rgba(120, 140, 255, 0.16);
   color: var(--muted);
   font-weight: 600;
   border-radius: 12px;
-  padding: 8px 10px;
+  padding: 10px 12px;
   cursor: pointer;
   transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
   display: inline-flex;
   justify-content: center;
   align-items: center;
   min-height: 40px;
+  width: 100%;
 }
 
 .house-toggle:hover,
 .house-toggle:focus-visible {
-  background: rgba(107, 91, 255, 0.18);
-  box-shadow: 0 10px 24px -18px rgba(81, 66, 208, 0.7);
+  background: rgba(120, 140, 255, 0.26);
+  box-shadow: 0 14px 26px -22px rgba(81, 66, 208, 0.65);
 }
 
 .house-toggle.is-selected {
-  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(255, 111, 145, 0.85));
+  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(108, 190, 255, 0.85));
   color: white;
   box-shadow: 0 18px 36px -20px rgba(81, 66, 208, 0.75);
 }
@@ -747,15 +828,15 @@ input[type="checkbox"] {
 .house-tatami-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 6px;
+  gap: 8px;
 }
 
 .house-tatami {
-  aspect-ratio: 1 / 1;
+  aspect-ratio: 5 / 3;
   border-radius: 10px;
   border: none;
-  background: rgba(107, 91, 255, 0.1);
-  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.25);
+  background: rgba(120, 140, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(107, 134, 255, 0.45);
   cursor: pointer;
   transition: background var(--transition), transform var(--transition);
 }
@@ -777,18 +858,36 @@ input[type="checkbox"] {
 .house-side-levels {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 18px;
+  align-items: stretch;
 }
 
 .house-side-level {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
+  padding: 18px;
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1.5px rgba(126, 155, 255, 0.35);
+  align-items: stretch;
+  position: relative;
+  overflow: hidden;
+}
+
+.house-side-level::before {
+  content: "";
+  position: absolute;
+  inset: 10px 12px;
+  border-radius: 12px;
+  border: 1.5px dashed rgba(126, 155, 255, 0.35);
+  pointer-events: none;
 }
 
 .house-window-row {
   display: none;
-  gap: 10px;
+  gap: 12px;
+  justify-content: space-between;
 }
 
 .house-window {
@@ -796,15 +895,15 @@ input[type="checkbox"] {
   border-radius: 12px;
   border: none;
   padding: 14px 0;
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.2);
+  background: rgba(120, 140, 255, 0.12);
+  box-shadow: inset 0 0 0 1.5px rgba(107, 134, 255, 0.35);
   cursor: pointer;
   transition: background var(--transition), box-shadow var(--transition);
 }
 
 .house-window:hover,
 .house-window:focus-visible {
-  background: rgba(107, 91, 255, 0.16);
+  background: rgba(120, 140, 255, 0.24);
 }
 
 .house-window.is-selected {
@@ -827,38 +926,64 @@ input[type="checkbox"] {
 
 .house-outdoor-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(3, minmax(72px, 1fr));
+  gap: 16px;
+  justify-items: center;
+  width: 100%;
 }
 
 .house-outdoor-label {
-  font-weight: 600;
+  font-weight: 700;
   color: var(--accent-dark);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
 }
 
 .house-car,
 .house-tree {
   border: none;
-  border-radius: 16px;
-  padding: 16px 0;
-  background: rgba(255, 255, 255, 0.78);
-  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.2);
+  border-radius: 14px;
+  padding: 18px 0;
+  width: 100%;
+  background: rgba(120, 140, 255, 0.12);
+  box-shadow: inset 0 0 0 1.5px rgba(107, 134, 255, 0.45);
   cursor: pointer;
-  font-size: 1.6rem;
+  font-size: 1.8rem;
   transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+  position: relative;
+  overflow: hidden;
+}
+
+.house-car::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border: 2px dashed rgba(107, 134, 255, 0.5);
+  border-radius: 10px;
+  pointer-events: none;
+}
+
+.house-tree::before {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 999px;
+  background: radial-gradient(circle at 50% 35%, rgba(255, 255, 255, 0.55) 0%, rgba(107, 134, 255, 0.2) 60%, transparent 75%);
+  pointer-events: none;
 }
 
 .house-car:hover,
 .house-car:focus-visible,
 .house-tree:hover,
 .house-tree:focus-visible {
-  transform: translateY(-2px);
+  transform: translateY(-3px);
   box-shadow: 0 16px 32px -22px rgba(81, 66, 208, 0.8);
 }
 
 .house-car.is-selected,
 .house-tree.is-selected {
-  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(255, 111, 145, 0.85));
+  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(108, 190, 255, 0.85));
   color: white;
 }
 
@@ -869,24 +994,24 @@ input[type="checkbox"] {
 
 .house-selection-summary {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 12px;
-  background: rgba(255, 255, 255, 0.78);
-  border-radius: 16px;
-  padding: 16px;
-  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.16);
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+  background: rgba(229, 239, 255, 0.9);
+  border-radius: 20px;
+  padding: 20px;
+  box-shadow: inset 0 0 0 1.5px rgba(97, 128, 228, 0.35);
 }
 
 .house-summary-item {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   color: var(--muted);
 }
 
 .house-summary-item strong {
-  font-size: 1.2rem;
+  font-size: 1.3rem;
   color: var(--accent-dark);
 }
 
@@ -900,10 +1025,18 @@ input[type="checkbox"] {
 @media (max-width: 640px) {
   .house-layout {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      "plan"
+      "side"
+      "outdoor";
   }
 
   .house-floor-plan__rooms {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .house-outdoor-grid {
+    grid-template-columns: repeat(3, minmax(56px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- add a new house drawer with floor plan, side view, and outdoor sections for counter practice
- wire up game logic to manage house selections, hints, and answer checking alongside the new counters
- style the house layout to match existing drawer aesthetics and extend counter data with practice metadata

## Testing
- node --check game.js

------
https://chatgpt.com/codex/tasks/task_e_68e3ea60205883248dbd87ccec01d58c