### PR TITLE
Use SVG floorplan assets in house drawer

### DIFF
--- a/style.css
+++ b/style.css
@@ -663,382 +663,200 @@ input[type="checkbox"] {
 .house-layout {
   display: grid;
   gap: 28px;
-  grid-template-columns: minmax(320px, 1fr) minmax(220px, 0.75fr);
-  grid-template-areas:
-    "plan side"
-    "outdoor side";
-  justify-content: center;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
   align-items: start;
-  margin: 0 auto;
-  max-width: 760px;
-}
-
-.house-floor-plan {
-  grid-area: plan;
-}
-
-.house-side-view {
-  grid-area: side;
-  justify-content: space-between;
-}
-
-.house-outdoor {
-  grid-area: outdoor;
-  align-items: center;
-  text-align: center;
-}
-
-.house-outdoor::after {
-  content: "";
-  position: absolute;
-  left: 10%;
-  right: 10%;
-  bottom: 18px;
-  height: 4px;
-  background: linear-gradient(90deg, rgba(107, 134, 255, 0.45), rgba(108, 190, 255, 0.55));
-  border-radius: 999px;
-  pointer-events: none;
 }
 
 .house-floor-plan,
-.house-side-view,
-.house-outdoor {
-  position: relative;
-  border-radius: 22px;
-  padding: 24px 24px 28px;
-  background: rgba(229, 239, 255, 0.9);
-  box-shadow: inset 0 0 0 1.5px rgba(97, 128, 228, 0.35), 0 18px 36px -26px rgba(65, 78, 146, 0.45);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.house-floor-plan::before,
-.house-side-view::before,
-.house-outdoor::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image:
-    linear-gradient(90deg, rgba(126, 155, 255, 0.15) 1px, transparent 1px),
-    linear-gradient(rgba(126, 155, 255, 0.15) 1px, transparent 1px);
-  background-size: 28px 28px;
-  opacity: 0.7;
-  pointer-events: none;
-}
-
-.house-floor-plan > *,
-.house-side-view > *,
-.house-outdoor > * {
-  position: relative;
-  z-index: 1;
-}
-
-.house-outdoor-section {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: center;
-}
-
-.house-floor-plan__level {
-  display: grid;
-  gap: 16px;
-  padding: 18px;
-  background: rgba(255, 255, 255, 0.68);
-  border-radius: 16px;
-  box-shadow: inset 0 0 0 1.5px rgba(126, 155, 255, 0.35);
-  transition: transform var(--transition);
-}
-
-.house-floor-plan__level:hover {
-  transform: translateY(-2px);
-}
-
-.house-floor-plan__label {
-  font-weight: 700;
-  color: var(--accent-dark);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.85rem;
-}
-
-.house-floor-plan__label span:first-child {
-  font-size: 1rem;
-  letter-spacing: 0.12em;
-}
-
-.house-floor-plan__label span:last-child {
-  font-size: 1.2rem;
-}
-
-.house-floor-plan__rooms {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 14px;
-}
-
-.house-room {
-  background: rgba(255, 255, 255, 0.74);
-  border-radius: 14px;
-  padding: 12px;
-  box-shadow: inset 0 0 0 1.5px rgba(126, 155, 255, 0.35);
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  align-items: stretch;
-}
-
-.house-toggle {
-  border: none;
-  background: rgba(120, 140, 255, 0.16);
-  color: var(--muted);
-  font-weight: 600;
-  border-radius: 12px;
-  padding: 10px 12px;
-  cursor: pointer;
-  transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 40px;
-  width: 100%;
-}
-
-.house-toggle:hover,
-.house-toggle:focus-visible {
-  background: rgba(120, 140, 255, 0.26);
-  box-shadow: 0 14px 26px -22px rgba(81, 66, 208, 0.65);
-}
-
-.house-toggle.is-selected {
-  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(108, 190, 255, 0.85));
-  color: white;
-  box-shadow: 0 18px 36px -20px rgba(81, 66, 208, 0.75);
-}
-
-.house-toggle.is-target:not(.is-selected) {
-  box-shadow: inset 0 0 0 2px rgba(107, 91, 255, 0.4);
-}
-
-.house-tatami-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-}
-
-.house-tatami {
-  aspect-ratio: 5 / 3;
-  border-radius: 10px;
-  border: none;
-  background: rgba(120, 140, 255, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(107, 134, 255, 0.45);
-  cursor: pointer;
-  transition: background var(--transition), transform var(--transition);
-}
-
-.house-tatami:hover,
-.house-tatami:focus-visible {
-  background: rgba(107, 91, 255, 0.18);
-}
-
-.house-tatami.is-selected {
-  background: linear-gradient(135deg, rgba(107, 91, 255, 0.88), rgba(255, 111, 145, 0.75));
-  box-shadow: 0 12px 28px -18px rgba(81, 66, 208, 0.7);
-}
-
-.house-tatami.is-target:not(.is-selected) {
-  box-shadow: inset 0 0 0 2px rgba(107, 91, 255, 0.4);
-}
-
-.house-side-levels {
+.house-side-view {
   display: flex;
   flex-direction: column;
   gap: 18px;
-  align-items: stretch;
 }
 
-.house-side-level {
+.house-outdoor {
+  display: none;
+}
+
+.house-floor-stack {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 18px;
-  background: rgba(255, 255, 255, 0.65);
-  border-radius: 16px;
-  box-shadow: inset 0 0 0 1.5px rgba(126, 155, 255, 0.35);
-  align-items: stretch;
+  gap: 18px;
+}
+
+.house-floor,
+.house-side-card {
   position: relative;
+  padding: 18px;
+  border-radius: 20px;
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.96), rgba(230, 238, 255, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.18), 0 18px 36px -28px rgba(44, 35, 92, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
   overflow: hidden;
 }
 
-.house-side-level::before {
-  content: "";
-  position: absolute;
-  inset: 10px 12px;
-  border-radius: 12px;
-  border: 1.5px dashed rgba(126, 155, 255, 0.35);
+.house-side-card {
+  align-self: stretch;
+}
+
+.house-floor__label,
+.house-side-card__label {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-dark);
+  font-weight: 700;
+}
+
+.house-floor svg,
+.house-side-card svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.12);
+}
+
+.house-floor svg text,
+.house-side-card svg text {
   pointer-events: none;
 }
 
-.house-window-row {
-  display: none;
-  gap: 12px;
-  justify-content: space-between;
+.house-drawer--windows .house-side-card {
+  box-shadow: inset 0 0 0 2px rgba(107, 91, 255, 0.35), 0 20px 38px -30px rgba(107, 91, 255, 0.45);
+}
+
+.house-selectable {
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.house-svg [data-selection-type] {
+  vector-effect: non-scaling-stroke;
+  stroke: transparent;
+  stroke-width: 0;
+  transition: stroke var(--transition), fill var(--transition), fill-opacity var(--transition), opacity var(--transition), filter var(--transition);
+}
+
+.house-svg [data-selection-type]:hover {
+  filter: brightness(1.05);
+}
+
+.house-svg [data-selection-type]:focus-visible {
+  stroke: rgba(107, 91, 255, 0.95);
+  stroke-width: 3;
+}
+
+.house-svg [data-selection-type].is-selected {
+  stroke: rgba(107, 91, 255, 0.95);
+  stroke-width: 3;
+  stroke-dasharray: none;
+  filter: drop-shadow(0 0 12px rgba(107, 91, 255, 0.35));
+}
+
+.house-svg [data-selection-type].is-target:not(.is-selected) {
+  stroke: rgba(107, 91, 255, 0.8);
+  stroke-width: 2.4;
+  stroke-dasharray: 8 6;
+  animation: house-target-pulse 2.4s ease-in-out infinite;
+}
+
+.house-svg [data-selection-type="tatami"].is-selected {
+  fill: #ffe38f;
+}
+
+.house-svg [data-selection-type="rooms"].is-selected {
+  fill-opacity: 0.92;
+}
+
+.house-svg [data-selection-type="cars"].is-selected {
+  fill: #ffc95f;
+}
+
+.house-svg [data-selection-type="trees"].is-selected {
+  stroke: rgba(52, 168, 83, 0.85);
+  stroke-width: 4;
 }
 
 .house-window {
-  flex: 1;
-  border-radius: 12px;
-  border: none;
-  padding: 14px 0;
-  background: rgba(120, 140, 255, 0.12);
-  box-shadow: inset 0 0 0 1.5px rgba(107, 134, 255, 0.35);
-  cursor: pointer;
-  transition: background var(--transition), box-shadow var(--transition);
+  fill: rgba(255, 255, 255, 0.85);
+  stroke: rgba(91, 112, 255, 0.35);
+  stroke-width: 1.5;
 }
 
-.house-window:hover,
-.house-window:focus-visible {
-  background: rgba(120, 140, 255, 0.24);
-}
-
-.house-window.is-selected {
-  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(255, 111, 145, 0.85));
-  color: white;
-  box-shadow: 0 16px 32px -18px rgba(81, 66, 208, 0.75);
-}
-
-.house-window.is-target:not(.is-selected) {
-  box-shadow: inset 0 0 0 2px rgba(107, 91, 255, 0.45);
-}
-
-.house-drawer--windows .house-floor-toggle {
-  display: none;
-}
-
-.house-drawer--windows .house-window-row {
-  display: flex;
-}
-
-.house-outdoor-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(72px, 1fr));
-  gap: 16px;
-  justify-items: center;
-  width: 100%;
-}
-
-.house-outdoor-label {
-  font-weight: 700;
-  color: var(--accent-dark);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  font-size: 0.8rem;
-}
-
-.house-car,
-.house-tree {
-  border: none;
-  border-radius: 14px;
-  padding: 18px 0;
-  width: 100%;
-  background: rgba(120, 140, 255, 0.12);
-  box-shadow: inset 0 0 0 1.5px rgba(107, 134, 255, 0.45);
-  cursor: pointer;
-  font-size: 1.8rem;
-  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
-  position: relative;
-  overflow: hidden;
-}
-
-.house-car::before {
-  content: "";
-  position: absolute;
-  inset: 6px;
-  border: 2px dashed rgba(107, 134, 255, 0.5);
-  border-radius: 10px;
-  pointer-events: none;
-}
-
-.house-tree::before {
-  content: "";
-  position: absolute;
-  inset: 10px;
-  border-radius: 999px;
-  background: radial-gradient(circle at 50% 35%, rgba(255, 255, 255, 0.55) 0%, rgba(107, 134, 255, 0.2) 60%, transparent 75%);
-  pointer-events: none;
-}
-
-.house-car:hover,
-.house-car:focus-visible,
-.house-tree:hover,
-.house-tree:focus-visible {
-  transform: translateY(-3px);
-  box-shadow: 0 16px 32px -22px rgba(81, 66, 208, 0.8);
-}
-
-.house-car.is-selected,
-.house-tree.is-selected {
-  background: linear-gradient(135deg, rgba(107, 91, 255, 0.9), rgba(108, 190, 255, 0.85));
-  color: white;
-}
-
-.house-car.is-target:not(.is-selected),
-.house-tree.is-target:not(.is-selected) {
-  box-shadow: inset 0 0 0 2px rgba(107, 91, 255, 0.45);
+.house-svg [data-selection-type="windows"].is-selected {
+  fill: rgba(107, 91, 255, 0.85);
+  stroke: rgba(48, 43, 130, 0.8);
 }
 
 .house-selection-summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 16px;
-  background: rgba(229, 239, 255, 0.9);
+  gap: 14px;
+  background: linear-gradient(155deg, rgba(229, 239, 255, 0.9), rgba(255, 239, 250, 0.85));
   border-radius: 20px;
-  padding: 20px;
-  box-shadow: inset 0 0 0 1.5px rgba(97, 128, 228, 0.35);
+  padding: 18px 20px;
+  box-shadow: inset 0 0 0 1.5px rgba(107, 91, 255, 0.18);
 }
 
 .house-summary-item {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 0.95rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.82);
   color: var(--muted);
+  font-size: 0.95rem;
 }
 
 .house-summary-item strong {
-  font-size: 1.3rem;
+  font-size: 1.35rem;
   color: var(--accent-dark);
 }
 
 .house-summary-item.is-target {
-  background: linear-gradient(135deg, rgba(107, 91, 255, 0.12), rgba(255, 111, 145, 0.1));
-  border-radius: 12px;
-  padding: 10px;
-  box-shadow: inset 0 0 0 1px rgba(107, 91, 255, 0.2);
+  background: rgba(107, 91, 255, 0.16);
+  box-shadow: inset 0 0 0 1.5px rgba(107, 91, 255, 0.4);
+  color: var(--accent-dark);
 }
 
-@media (max-width: 640px) {
+@keyframes house-target-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.65;
+  }
+}
+
+@media (max-width: 880px) {
   .house-layout {
     grid-template-columns: 1fr;
-    grid-template-areas:
-      "plan"
-      "side"
-      "outdoor";
   }
 
-  .house-floor-plan__rooms {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .house-outdoor-grid {
-    grid-template-columns: repeat(3, minmax(56px, 1fr));
+  .house-side-card {
+    order: -1;
   }
 }
+
+@media (max-width: 560px) {
+  .house-floor,
+  .house-side-card {
+    padding: 16px;
+  }
+
+  .house-selection-summary {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}
+
 
 /* Clock drawer */
 .clock-face-wrapper {


### PR DESCRIPTION
## Summary
- load the house drawer layout directly from the provided SVG floorplan and side view assets
- treat SVG regions as interactive selections during initialization while reusing existing selection logic
- restyle the drawer to showcase the stacked floors and refreshed summary panels

## Testing
- Manual UI verification in local browser

------
https://chatgpt.com/codex/tasks/task_e_68e42b6e5a808324b4665d57451e0502