### PR TITLE
Add TTS fallback for browsers without Web Speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,13 @@
 A fun little game to practice your Japanese counters
 
 A browser-based game for practicing **Japanese counters**.  
-Players serve customers in Maru’s shop by dragging the right number of items to the counter.  
-Requests are spoken aloud in Japanese (TTS) and support irregular counter readings (e.g. いっぴき, はっぽん).  
+Players serve customers in Maru’s shop by dragging the right number of items to the counter.
+Requests are spoken aloud in Japanese (TTS) and support irregular counter readings (e.g. いっぴき, はっぽん).
+
+## Voice playback
+
+Open the in-game **Settings** menu to enable or disable voice prompts. When a browser does not
+support the Web Speech API (or blocks it for privacy reasons), you can toggle **Use fallback voice
+service** to stream audio from Google Translate’s public TTS endpoint. The fallback runs entirely in
+the browser; no extra backend is required. Disable the toggle if you prefer not to load audio from
+Google’s servers.

--- a/index.html
+++ b/index.html
@@ -100,12 +100,20 @@
   <div id="settingsModal" class="modal">
     <div class="modal-content">
       <h2>Settings</h2>
-      <label>
+      <label class="settings-inline">
         <input type="checkbox" id="furiganaCheckbox"> Show Furigana
       </label>
       <br>
-      <label>
+      <label class="settings-inline">
         <input type="checkbox" id="voiceCheckbox"> Enable Voice
+      </label>
+      <br>
+      <label class="settings-option">
+        <input type="checkbox" id="fallbackVoiceCheckbox">
+        <span>
+          Use fallback voice service
+          <span class="settings-hint">Streams audio from Google Translate when your browser can’t use speech synthesis.</span>
+        </span>
       </label>
       <br><br>
       <button id="openCounterPage" class="ghost">Manage counters</button>

--- a/style.css
+++ b/style.css
@@ -507,6 +507,30 @@ button.primary:focus-visible {
   justify-content: center;
 }
 
+.modal-content .settings-inline {
+  justify-content: center;
+}
+
+.modal-content .settings-option {
+  color: var(--neutral);
+  justify-content: flex-start;
+  align-items: flex-start;
+  text-align: left;
+  gap: 12px;
+}
+
+.settings-option > span {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-option .settings-hint {
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
 input[type="checkbox"] {
   width: 18px;
   height: 18px;


### PR DESCRIPTION
## Summary
- add a streaming TTS fallback that uses Google Translate when the Web Speech API is unavailable or blocked
- expose a settings toggle and UI polish so players can opt into or out of the fallback voice
- update README guidance and clean up audio lifecycle handling for the new playback flow

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4f27ffb808324a54fb5ab0dc2aa8e