### PR TITLE
Improve house drawer interactions

### DIFF
--- a/game.js
+++ b/game.js
@@ -2146,7 +2146,7 @@ function dispatchCalendarAnswer(selection) {
   }
 }
 
-function registerHouseSelectable(element, type, { stopPropagation = false } = {}) {
+function registerHouseSelectable(element, type, { stopPropagation = false, onActivate = null } = {}) {
   if (!element || !HOUSE_SELECTION_KEYS.includes(type)) return;
   const houseState = drawerState.house;
   if (!element.classList.contains("house-selectable")) {
@@ -2166,11 +2166,18 @@ function registerHouseSelectable(element, type, { stopPropagation = false } = {}
     element.dataset.selectionId = `${type}-${houseState.elements[type].length + 1}`;
   }
   element.setAttribute("aria-pressed", "false");
+  const activateElement = event => {
+    if (typeof onActivate === "function") {
+      onActivate(event, element);
+    } else {
+      toggleSelection(element);
+    }
+  };
   const activate = event => {
     if (stopPropagation) {
       event.stopPropagation();
     }
-    toggleSelection(element);
+    activateElement(event);
   };
   element.addEventListener("click", activate);
   element.addEventListener("keydown", event => {
@@ -2179,7 +2186,7 @@ function registerHouseSelectable(element, type, { stopPropagation = false } = {}
       if (stopPropagation) {
         event.stopPropagation();
       }
-      toggleSelection(element);
+      activateElement(event);
     }
   });
   houseState.elements[type].push(element);
@@ -2206,6 +2213,27 @@ function toggleSelection(element, forceState) {
   element.setAttribute("aria-pressed", shouldSelect ? "true" : "false");
   updateHouseSelectionSummary();
   return shouldSelect;
+}
+
+function incrementHouseSelection(type) {
+  if (!HOUSE_SELECTION_KEYS.includes(type)) return false;
+  const houseState = drawerState.house;
+  const elements = houseState.elements[type];
+  if (!Array.isArray(elements) || elements.length === 0) {
+    return false;
+  }
+  const selectedSet = houseState.selected[type] instanceof Set ? houseState.selected[type] : null;
+  const nextElement = elements.find(element => {
+    if (!element) return false;
+    const id = element.dataset ? element.dataset.selectionId : null;
+    if (!id) return false;
+    return !selectedSet || !selectedSet.has(id);
+  });
+  if (!nextElement) {
+    return false;
+  }
+  toggleSelection(nextElement, true);
+  return true;
 }
 
 function resetHouseSelections() {
@@ -2242,13 +2270,31 @@ function updateHouseSelectionSummary() {
   HOUSE_SELECTION_KEYS.forEach(key => {
     const item = document.createElement("div");
     item.className = "house-summary-item";
+    item.dataset.selectionType = key;
+    item.setAttribute("role", "button");
+    item.setAttribute("tabindex", "0");
     if (key === activeTarget) {
       item.classList.add("is-target");
     }
+    const title = getHouseTargetTitle(key);
+    const normalizedTitle = typeof title === "string" ? title.toLowerCase() : "items";
     const label = document.createElement("span");
-    label.textContent = getHouseTargetTitle(key);
+    label.textContent = title;
     const count = document.createElement("strong");
     count.textContent = snapshot[key];
+    const ariaLabel = `Increase ${normalizedTitle} selection (currently ${snapshot[key]})`;
+    item.setAttribute("aria-label", ariaLabel);
+    item.title = `Click to add more ${normalizedTitle}`;
+    const increment = () => {
+      incrementHouseSelection(key);
+    };
+    item.addEventListener("click", increment);
+    item.addEventListener("keydown", event => {
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+        event.preventDefault();
+        increment();
+      }
+    });
     item.append(label, count);
     fragment.appendChild(item);
   });
@@ -2350,7 +2396,17 @@ function registerFloorPlanElements(svgEl, floorNumber, { includeOutdoor = false 
         `Tatami ${tatamiIndex + 1} in room ${groupIndex + 1} on ${getFloorLabel(floorNumber).toLowerCase()}`
       );
       tatamiRect.dataset.selectionId = `floor-${floorNumber}-room-${groupIndex + 1}-tatami-${tatamiIndex + 1}`;
-      registerHouseSelectable(tatamiRect, "tatami", { stopPropagation: true });
+      registerHouseSelectable(tatamiRect, "tatami", {
+        stopPropagation: true,
+        onActivate: (event, element) => {
+          const activeTarget = drawerState.house.activeTarget;
+          if (activeTarget === "rooms" && roomRect) {
+            toggleSelection(roomRect);
+          } else {
+            toggleSelection(element);
+          }
+        }
+      });
     });
   });
 

--- a/style.css
+++ b/style.css
@@ -813,6 +813,22 @@ input[type="checkbox"] {
   background: rgba(255, 255, 255, 0.82);
   color: var(--muted);
   font-size: 0.95rem;
+  user-select: none;
+}
+
+.house-summary-item[role="button"] {
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.house-summary-item[role="button"]:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(107, 91, 255, 0.18);
+}
+
+.house-summary-item[role="button"]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(107, 91, 255, 0.45);
 }
 
 .house-summary-item strong {


### PR DESCRIPTION
## Summary
- allow tatami mats to toggle their associated room when the house counter is targeting rooms
- add a helper that lets the house selection summary increment counts via clicks or keyboard input
- enhance the summary tile styling with hover/focus feedback for the new interactive behavior

## Testing
- Manual testing: Opened the house drawer, selected rooms via tatami mats, and used the summary counters to add additional selections in the browser


------
https://chatgpt.com/codex/tasks/task_e_68e42f76ae148324a3db2e1e9361818d