### PR TITLE
Fix room selection fallback for tatami

### DIFF
--- a/game.js
+++ b/game.js
@@ -2618,7 +2618,13 @@ function registerFloorPlanElements(svgEl, floorNumber, { includeOutdoor = false 
   if (!svgEl) return;
   const roomGroups = svgEl.querySelectorAll(".Room_Grouped");
   roomGroups.forEach((group, groupIndex) => {
-    const roomRect = group.querySelector(".Room");
+    let roomRect = group.querySelector(".Room");
+    if (!roomRect) {
+      roomRect = group.querySelector("rect");
+      if (roomRect) {
+        roomRect.classList.add("Room");
+      }
+    }
     if (roomRect) {
       ensureHouseElementLabel(roomRect, `Room ${groupIndex + 1} on ${getFloorLabel(floorNumber).toLowerCase()}`);
       roomRect.dataset.selectionId = `floor-${floorNumber}-room-${groupIndex + 1}`;


### PR DESCRIPTION
## Summary
- ensure each floor plan room rect is selectable even if the SVG is missing the `Room` class
- automatically assign the room class to the first rect in a room group when needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f5cc7fcc83248511e718ccfccca5